### PR TITLE
understand phpunit coverage txt format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ But no need to generate any new token, you can use the Github action token (`${{
     token: ${{ github.token }}
 ```
 
+#### Report name
+
+```yml
+- uses: devmasx/coverage-check-action@v1.2.0
+  with:
+    type: lcov
+    result_path: coverage/example.lcov
+    min_coverage: 90
+    token: ${{ github.token }}
+    report_name: "My Github Action Check Name"
+```
+
 ## Screenshots
 
 ![Success](./screenshots/success.png)

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: "green"
 inputs:
   type:
-    description: "lcov | simplecov"
+    description: "lcov | simplecov | phpunit"
     required: true
     default: "lcov"
   token:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   min_coverage:
     description: "Minimum coverage"
     default: "80"
+  report_name:
+    description: "Name of the github action check"
+    default: "Coverage"
   result_path:
     description: "Json with coverage result"
     required: true

--- a/lib/coverage_report.rb
+++ b/lib/coverage_report.rb
@@ -7,6 +7,8 @@ class CoverageReport
         simplecov(report_path, data)
       elsif type == 'lcov'
         lcov(report_path, data)
+      elsif type == 'phpunit'
+        phpunit(report_path, data)
       else
         raise 'InvalidCoverageReportType'
       end
@@ -25,6 +27,12 @@ class CoverageReport
       { 'lines' => { 'covered_percent' => lcov_covered_percent(lcov_result), 'minumum_percent' => minumum_percent } }
     end
 
+    def phpunit(report_path, data)
+      phpunit_result = execute_phpunit_parse(report_path)
+      minumum_percent = data[:min]
+      { 'lines' => { 'covered_percent' => phpunit_covered_percent(phpunit_result), 'minumum_percent' => minumum_percent} }
+    end
+
     private
 
     def lcov_covered_percent(lcov_result)
@@ -37,6 +45,22 @@ class CoverageReport
     def execute_lcov_parse(report_path)
       bin_path = "#{File.dirname(__FILE__)}/../bin"
       JSON.parse(`node #{bin_path}/lcov-parse.js #{report_path}`)
+    end
+
+
+    def phpunit_covered_percent(phpunit_result)
+      # example for 
+      # phpunit --coverage-text
+      # Summary:                    
+      # Classes: 10.14% (14/138)   
+      # Methods: 16.67% (107/642)  
+      # Lines:   13.95% (1059/7591)
+
+      /Lines: * ([0-9\.]*)%/.match(phpunit_result)[1]
+    end
+
+    def execute_phpunit_parse(report_path)
+      File.read(report_path)
     end
 
     def read_json(path)

--- a/lib/coverage_report.rb
+++ b/lib/coverage_report.rb
@@ -29,6 +29,8 @@ class CoverageReport
 
     def phpunit(report_path, data)
       phpunit_result = execute_phpunit_parse(report_path)
+      puts phpunit_result
+      puts phpunit_covered_percent(phpunit_result)
       minumum_percent = data[:min]
       { 'lines' => { 'covered_percent' => phpunit_covered_percent(phpunit_result), 'minumum_percent' => minumum_percent} }
     end

--- a/lib/coverage_report.rb
+++ b/lib/coverage_report.rb
@@ -29,8 +29,6 @@ class CoverageReport
 
     def phpunit(report_path, data)
       phpunit_result = execute_phpunit_parse(report_path)
-      puts phpunit_result
-      puts phpunit_covered_percent(phpunit_result)
       minumum_percent = data[:min]
       { 'lines' => { 'covered_percent' => phpunit_covered_percent(phpunit_result), 'minumum_percent' => minumum_percent} }
     end
@@ -58,7 +56,7 @@ class CoverageReport
       # Methods: 16.67% (107/642)  
       # Lines:   13.95% (1059/7591)
 
-      /Lines: * ([0-9\.]*)%/.match(phpunit_result)[1]
+      /Lines: * ([0-9\.]*)%/.match(phpunit_result)[1].to_f
     end
 
     def execute_phpunit_parse(report_path)

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class GithubCheckRunService
-  CHECK_NAME = defined? @github_data[:name] ? @github_data[:name] : 'Coverage'
-
   def initialize(report, github_data, report_adapter)
     @report = report
     @github_data = github_data
@@ -34,7 +32,7 @@ class GithubCheckRunService
 
   def create_check_payload
     {
-      name: CHECK_NAME,
+      name: @report_name,
       head_sha: @github_data[:sha],
       status: 'in_progress',
       started_at: Time.now.iso8601
@@ -43,13 +41,13 @@ class GithubCheckRunService
 
   def update_check_payload
     {
-      name: CHECK_NAME,
+      name: @report_name,
       head_sha: @github_data[:sha],
       status: 'completed',
       completed_at: Time.now.iso8601,
       conclusion: @conclusion,
       output: {
-        title: "#{CHECK_NAME} #{@percent}%",
+        title: "#{@report_name} #{@percent}%",
         summary: @summary,
         annotations: @annotations
       }

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class GithubCheckRunService
-  CHECK_NAME = 'Coverage'
+  CHECK_NAME = defined? @github_data[:name] ? @github_data[:name] : 'Coverage'
 
   def initialize(report, github_data, report_adapter)
     @report = report

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class GithubCheckRunService
-  def initialize(report, github_data, report_adapter)
+  def initialize(report, github_data, report_name, report_adapter)
     @report = report
     @github_data = github_data
+    @report_name = report_name
     @report_adapter = report_adapter
     @client = GithubClient.new(@github_data[:token], user_agent: 'coverage-action')
   end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -17,11 +17,12 @@ end
   sha: ENV['GITHUB_SHA'],
   token: ENV['INPUT_TOKEN'],
   owner: ENV['GITHUB_REPOSITORY_OWNER'] || @event_json.dig('repository', 'owner', 'login'),
-  repo: ENV['GITHUB_REPOSITORY_NAME'] || @event_json.dig('repository', 'name')
+  repo: ENV['GITHUB_REPOSITORY_NAME'] || @event_json.dig('repository', 'name'),
 }
 
 @coverage_type = ENV['INPUT_TYPE']
 @report_path = ENV['INPUT_RESULT_PATH']
+@report_name: ENV['INPUT_REPORT_NAME']
 @data = { min: ENV['INPUT_MIN_COVERAGE'] }
 
 @report = CoverageReport.generate(@coverage_type, @report_path, @data)

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -27,4 +27,4 @@ end
 
 @report = CoverageReport.generate(@coverage_type, @report_path, @data)
 
-GithubCheckRunService.new(@report, @github_data, ReportAdapter).run
+GithubCheckRunService.new(@report, @github_data, @report_name, ReportAdapter).run

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -22,7 +22,7 @@ end
 
 @coverage_type = ENV['INPUT_TYPE']
 @report_path = ENV['INPUT_RESULT_PATH']
-@report_name: ENV['INPUT_REPORT_NAME']
+@report_name = ENV['INPUT_REPORT_NAME']
 @data = { min: ENV['INPUT_MIN_COVERAGE'] }
 
 @report = CoverageReport.generate(@coverage_type, @report_path, @data)

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -7,6 +7,8 @@ class ReportAdapter
     ANNOTATION_LEVEL = { notice: 'notice', warning: 'warning', failure: 'failure' }.freeze
 
     def conslusion(report)
+      puts report
+      puts lines_covered_percent(report)
       lines_covered_percent(report) >= lines_minimum_percent(report).to_f ? CONCLUSION_TYPES[:success] : CONCLUSION_TYPES[:failure]
     end
 

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -7,8 +7,6 @@ class ReportAdapter
     ANNOTATION_LEVEL = { notice: 'notice', warning: 'warning', failure: 'failure' }.freeze
 
     def conslusion(report)
-      puts report
-      puts lines_covered_percent(report)
       lines_covered_percent(report) >= lines_minimum_percent(report).to_f ? CONCLUSION_TYPES[:success] : CONCLUSION_TYPES[:failure]
     end
 

--- a/spec/github_check_run_service_spec.rb
+++ b/spec/github_check_run_service_spec.rb
@@ -7,7 +7,8 @@ describe GithubCheckRunService do
     { 'lines' => { 'covered_percent' => 80, 'minumum_percent' => 80 } }
   end
   let(:github_data) { { sha: 'sha', token: 'token', owner: 'owner', repo: 'repository_name' } }
-  let(:service) { GithubCheckRunService.new(report, github_data, ReportAdapter) }
+  let(:report_name) { 'Coverage' }
+  let(:service) { GithubCheckRunService.new(report, github_data, report_name, ReportAdapter) }
 
   it '#run' do
     stub_request(:any, 'https://api.github.com/repos/owner/repository_name/check-runs/id')


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
feature
## Description
I couldn't find a way to use this for a php based project which I test and generate code-coverage with phpunit. 
So I added the possibility to use also from phpunit generated code coverage in text-format via regexp. 


## Why should this be added
More People and Projects can use it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing 
